### PR TITLE
Fix Zoom to Click issue in GeoMAP

### DIFF
--- a/ckanext/wet_boew/plugins.py
+++ b/ckanext/wet_boew/plugins.py
@@ -80,7 +80,6 @@ class WetTheme(p.SingletonPlugin):
       gjson = json.loads(gjson_str)
       coords = gjson['coordinates']
 
-      import pdb; pdb.set_trace()        
       # test to see if the latitude and longitude have been transposed. Since all co-ordinates are in 
       # Canada, the latitude should be negative.
       if coords:


### PR DESCRIPTION
Some of the GeoJSON has the latitude and longitude transposed. Check for this condition to write out WKT that works with the GeoMAP.

Some keen pythonista can probably make this change cleaner
