### PR TITLE
Ensure share widget only appears on the public portal, not the registry

### DIFF
--- a/ckanext/wet_boew/templates/ckan/package/read_base.html
+++ b/ckanext/wet_boew/templates/ckan/package/read_base.html
@@ -31,6 +31,7 @@
   </div>
   </div class="clear">
   {% endif %}
+  {% block share_widget %}{% include "package/snippets/share_widget.html" %}{% endblock %}
 {% endblock toolbar %}
 
 {% block main_content %}

--- a/ckanext/wet_boew/templates/ckan/package/snippets/share_widget.html
+++ b/ckanext/wet_boew/templates/ckan/package/snippets/share_widget.html
@@ -1,0 +1,4 @@
+{% block share_widget %}
+  <div class="wet-boew-share span-5 margin-bottom-none" data-wet-boew='{"sites":["facebook","google", "twitter"]}'></div>
+  <div class="clear"></div>
+{% endblock %}


### PR DESCRIPTION
Share widget added to the WET extension
