### PR TITLE
Changes for better stand-alone ckanext-wet-boew usage

### DIFF
--- a/ckanext/wet_boew/templates/header.html
+++ b/ckanext/wet_boew/templates/header.html
@@ -1,6 +1,8 @@
 <div class="container">
     <div class="row">
         <section id="wb-lng" class="visible-md visible-lg">
+            {%- block pre_top_nav -%}
+            {%- endblock -%}
             <h2>Accounts menu and Language selection</h2>
             <ul class="text-right">
                 {% set current_url = request.environ.CKAN_CURRENT_URL %}

--- a/ckanext/wet_boew/templates/macros/form.html
+++ b/ckanext/wet_boew/templates/macros/form.html
@@ -276,7 +276,7 @@ Example:
 
 #}
 {% macro input_block(for, label="", error="", classes=[], control_classes=[], extra_html="", is_required=false) %}
-   <div class="form-group{{ " " ~ classes | join(' ') }} {% if error and error is iterable %} has-error {% endif %}">
+   <div style="margin: 0" class="form-group{{ " " ~ classes | join(' ') }} {% if error and error is iterable %} has-error {% endif %}">
      {% if label != '' %}
       <label {% if for != '' %} for="{{ for }}" {% endif %} >{{ label or _('Custom') }}</label>
      {% endif %}

--- a/ckanext/wet_boew/templates/macros/form.html
+++ b/ckanext/wet_boew/templates/macros/form.html
@@ -234,9 +234,6 @@ Examples:
   {%- set extra_html = caller() if caller -%}
   {%- do classes.append('control-custom') -%}
 
-    <div class="span-1 margin-bottom-none row-start{{ " " ~ classes | join(' ') }} {% if error and error is iterable %} form-attention {% endif %}">
-        <label for="{{ for }}">{{ label or _('Custom') }}</label>
-     </div>
     <div class="input-prepend" style="display: inline-block;" {{ attributes(attrs) }}>
       <label for="{{ label_id }}" class="add-on span-1">Key</label>
       <div class="span-4">

--- a/ckanext/wet_boew/templates/package/snippets/resource_item.html
+++ b/ckanext/wet_boew/templates/package/snippets/resource_item.html
@@ -18,7 +18,7 @@
   {% block resource_item_description %}
   <td >
     <a href="{{ url }}" title="{{ res.name or res.description }}">
-      <span class="badge">{{ _('Download') }}</span>
+      <span class="badge">{{ _('Go to resource') }}</span>
     </a>
   </td>
   {% endblock %}

--- a/ckanext/wet_boew/templates/package/snippets/resources.html
+++ b/ckanext/wet_boew/templates/package/snippets/resources.html
@@ -11,7 +11,7 @@
           <ul class="unstyled nav nav-simple">
             {% for resource in resources %}
               <li class="nav-item{{ ' active' if active == resource.id }}">
-                {% link_for h.resource_display_name(resource)|truncate(35), controller='package', action=action or 'resource_read', id=pkg.name, resource_id=resource.id, inner_span=true %}
+                {% link_for h.resource_display_name(resource)|truncate(35) + ':' + resource.get('format', ''), controller='package', action=action or 'resource_read', id=pkg.name, resource_id=resource.id, inner_span=true %}
               </li>
             {% endfor %}
           </ul>

--- a/ckanext/wet_boew/templates/page.html
+++ b/ckanext/wet_boew/templates/page.html
@@ -105,7 +105,7 @@
     {% block pre_primary %}{% endblock %}
     {% block primary %}
     <div class="col-md-9 col-md-pull-3">
-    <main role="main" property="mainContentOfPage">
+    <main role="main" property="mainContentOfPage" style="padding-left: 10px">
 
       {% block flash %}
       {% if flash_messages %}

--- a/ckanext/wet_boew/templates/page.html
+++ b/ckanext/wet_boew/templates/page.html
@@ -53,11 +53,16 @@
       <div class="container nvbar"><h2>Site menu</h2>
 
         <div class="row">
-          <ul class="list-inline menu">
-            <li><a href="./index-en.html">WET project</a></li>
-            <li><a href="http://wet-boew.github.io/wet-boew/docs/start-en.html#implement">Implement WET</a></li>
-            <li><a href="http://wet-boew.github.io/wet-boew/docs/start-en.html">Contribute to WET</a></li>
-          </ul>
+            <ul class="list-inline menu">
+            {% block header_site_navigation_tabs %}
+            {{ h.build_nav_main(
+                ('search', _('Datasets')),
+                ('organizations_index', _('Organizations')),
+                ('group_index', _('Groups')),
+                ('about', _('About'))
+                ) }}
+                {% endblock %}
+            </ul>
         </div>
       </div>
     </nav>


### PR DESCRIPTION
Hi @thriuin,

I've been using the ckanext-wet-boew as a base for another CKAN project, and have fixed a few design things that crop up when using ckanext-wet-boew standalone withough ckanext-canada on top of it.

Sorry this pull request is a bit bulky. There isn't actually that much going on, mostly quite minor changes. I should also note I haven't tested it yet with ckanext-canada on top, so do take a look before you might merge.

The changes are:
- Add WET dist repo as a submodule, so the user doesn't need to download and copy files. You can just do `git clone --recursive ...` and it will pull everything in.
- WET doesn't bundle jquery anymore, so included jquery as a static file.
- In the base template, better support for overriding styles and favicons.
- Everything else is just design tweaks