### PR TITLE
Patches an issue displaying None/{} notes.

### DIFF
--- a/ckanext/wet_boew/templates/package/read.html
+++ b/ckanext/wet_boew/templates/package/read.html
@@ -50,7 +50,7 @@
     {% endblock %}
 
     {% block package_item_notes %}
-    {% if c.pkg_notes_formatted %}
+    {% if pkg.notes and c.pkg_notes_formatted %}
     <div class="col-md-12">
       {{ c.pkg_notes_formatted }}
     </div>


### PR DESCRIPTION
When pkg.notes is set to None/{} by an IPackageController
plugin after_view, c.pkg_notes_formatted still contains
the old value. This is a temporary fix pending a CKAN
patch.