### PR TITLE
Fix link to CKAN API documentation

### DIFF
--- a/ckanext/wet_boew/templates/footer.html
+++ b/ckanext/wet_boew/templates/footer.html
@@ -1,7 +1,7 @@
 <footer role="contentinfo" id="wb-info" class="visible-sm visible-md visible-lg wb-navcurr">
   <div class="container">
     {% block footer_content %}
-    <nav role="navigation" class="row"><h2>{% set api_url = 'http://docs.ckan.org/{0}/{1}/api.html'.format(request.environ.CKAN_LANG, g.ckan_doc_version) %}</h2>
+    <nav role="navigation" class="row"><h2>{% set api_url = 'http://docs.ckan.org/{0}/{1}/api/'.format(request.environ.CKAN_LANG, g.ckan_doc_version) %}</h2>
       <section class="col-sm-3"><h3>{{ _('About {0}').format(g.site_title) }}</h3>
           <ul class="list-unstyled">
             <li><a href="#">{{ _('Terms and Conditions') }}</a></li>


### PR DESCRIPTION
I've pulled in everywhere live (master, wet4).  Lobbing the change here to have it in 2.3 versions.