### PR TITLE
The Babel extractor in the setup breaks when doing a non-development install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,14 +29,6 @@ setup(
 	wet_boew=ckanext.wet_boew.plugins:WetTheme
     wet_boew_theme_gc_intranet=ckanext.wet_boew.plugins:GCIntranetTheme
     wet_boew_gcweb=ckanext.wet_boew.plugins:GCWebTheme
-
-    [babel.extractors]
-    ckan = ckan.lib.extract:extract_ckan
 	""",
-    message_extractors={
-        'ckanext': [
-            ('**.py', 'python', None),
-            ('**/templates/**.html', 'ckan', None),
-        ],
-    },
+
 )


### PR DESCRIPTION
There is a conflict with the version of pytz required by CKAN and the Babel plugin.

pkg_resources.VersionConflict: (pytz 2012j 
 raise VersionConflict(dist, req).with_context(dependent_req)\n    pkg_resources.VersionConflict: (pytz 2012j (..../lib/python2.7/site-packages), Requirement.parse('pytz>=0a'))