### PR TITLE
Revert "The Babel extractor in the setup breaks when doing a non-deve…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,14 @@ setup(
 	wet_boew=ckanext.wet_boew.plugins:WetTheme
     wet_boew_theme_gc_intranet=ckanext.wet_boew.plugins:GCIntranetTheme
     wet_boew_gcweb=ckanext.wet_boew.plugins:GCWebTheme
-	""",
 
+    [babel.extractors]
+    ckan = ckan.lib.extract:extract_ckan
+	""",
+    message_extractors={
+        'ckanext': [
+            ('**.py', 'python', None),
+            ('**/templates/**.html', 'ckan', None),
+        ],
+    },
 )


### PR DESCRIPTION
…lopment install. There is a conflict with the version of pytz required by CKAN and the Babel plugin."

This is needed, so will find another way to resolve pytz incompatability

This reverts commit 3871c6d475193961b6f09176771fdddb668cfc9a.